### PR TITLE
Resolve arguments validation error in RandomCrop

### DIFF
--- a/data/aug.py
+++ b/data/aug.py
@@ -13,8 +13,8 @@ def get_transforms(size):
             }
 
     aug_fn = augs['geometric']
-    crop_fn = {'random': albu.RandomCrop(size, size, always_apply=True),
-               'center': albu.CenterCrop(size, size, always_apply=True)}['random']
+    crop_fn = {'random': albu.RandomCrop(*size, always_apply=True),
+               'center': albu.CenterCrop(*size, always_apply=True)}['random']
 
     effect = albu.OneOf([albu.MotionBlur(blur_limit=21, always_apply=True),
                          albu.RandomRain(always_apply=True),


### PR DESCRIPTION
`__init__` method of `RandomCrop` class in `albumentations` is defined `def __init__(self, height: int, width: int, always_apply: bool = False, p: float = 1.0)` .
So if tuple named size like (112, 224) as first and second args used when you initialize this class, it raises a `ValidationError` in albumentations/core/validation.py, line 29.
To resolve this issue, I remove duplicated args size tuple and unpack it.

